### PR TITLE
switch to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RaduBerinde/axisds
+module github.com/RaduBerinde/axisds/v2
 
 go 1.23
 

--- a/regiontree/README.md
+++ b/regiontree/README.md
@@ -66,7 +66,7 @@ equality check:
 import (
 	"cmp"
     "fmt"
-    "github.com/RaduBerinde/axisds/regiontree"
+    "github.com/RaduBerinde/axisds/v2/regiontree"
 )
 
 func main() {

--- a/regiontree/region_tree.go
+++ b/regiontree/region_tree.go
@@ -19,7 +19,7 @@ import (
 	"iter"
 	"strings"
 
-	"github.com/RaduBerinde/axisds"
+	"github.com/RaduBerinde/axisds/v2"
 	"github.com/RaduBerinde/btreemap"
 )
 

--- a/regiontree/region_tree_test.go
+++ b/regiontree/region_tree_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/RaduBerinde/axisds"
+	"github.com/RaduBerinde/axisds/v2"
 	"github.com/RaduBerinde/btreemap"
 	"github.com/cockroachdb/datadriven"
 )


### PR DESCRIPTION
The iterators change is not backward compatible; change to v2 to avoid problems like https://github.com/cockroachdb/pebble/issues/5693