### PR TITLE
v3: improved APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RaduBerinde/axisds/v2
+module github.com/RaduBerinde/axisds/v3
 
 go 1.23
 

--- a/regiontree/region_tree.go
+++ b/regiontree/region_tree.go
@@ -25,6 +25,44 @@ import (
 
 type Boundary = axisds.Boundary
 
+// LowerBound defines an (optional) lower bound for region tree query methods.
+type LowerBound[B Boundary] struct {
+	isMin bool
+	key   B
+}
+
+// Min returns a LowerBound that does not constrain the lower end of the query.
+func Min[B Boundary]() LowerBound[B] { return LowerBound[B]{isMin: true} }
+
+// GE returns a lower bound that includes all regions at or after key.
+func GE[B Boundary](key B) LowerBound[B] { return LowerBound[B]{key: key} }
+
+func (lb LowerBound[B]) btreemapBound() btreemap.LowerBound[B] {
+	if lb.isMin {
+		return btreemap.Min[B]()
+	}
+	return btreemap.GE(lb.key)
+}
+
+// UpperBound defines an (optional) upper bound for region tree query methods.
+type UpperBound[B Boundary] struct {
+	isMax bool
+	key   B
+}
+
+// Max returns an UpperBound that does not constrain the upper end of the query.
+func Max[B Boundary]() UpperBound[B] { return UpperBound[B]{isMax: true} }
+
+// LT returns an upper bound that excludes regions at or after key.
+func LT[B Boundary](key B) UpperBound[B] { return UpperBound[B]{key: key} }
+
+func (ub UpperBound[B]) btreemapBound() btreemap.UpperBound[B] {
+	if ub.isMax {
+		return btreemap.Max[B]()
+	}
+	return btreemap.LT(ub.key)
+}
+
 // Property is an arbitrary type that represents a property of a region of a
 // one-dimensional axis.
 type Property any
@@ -210,35 +248,49 @@ func (t *T[B, P]) endBoundaryInfo(end B) (exists bool, afterProp P) {
 	return false, afterProp
 }
 
-// Enumerate all regions in the range [start, end) with non-zero property.
+// Enumerate all regions in the given range with non-zero property.
 //
 // Two consecutive regions can "touch" but not overlap; if they touch, their
 // properties are not equal.
 //
 // Enumerate can be called concurrently with other read-only methods (as long as
 // WithGC is not used).
-func (t *T[B, P]) Enumerate(start, end B, opts ...Option) iter.Seq2[axisds.Interval[B], P] {
+func (t *T[B, P]) Enumerate(
+	lower LowerBound[B], upper UpperBound[B], opts ...Option,
+) iter.Seq2[axisds.Interval[B], P] {
 	gc := hasWithGC(opts)
 	return func(yield func(i axisds.Interval[B], prop P) bool) {
-		t.enumerate(start, end, yield, gc)
+		t.enumerate(lower, upper, yield, gc)
 	}
 }
 
 func (t *T[B, P]) enumerate(
-	start, end B, emit func(i axisds.Interval[B], prop P) bool, withGC bool,
+	lower LowerBound[B],
+	upper UpperBound[B],
+	emit func(i axisds.Interval[B], prop P) bool,
+	withGC bool,
 ) {
-	if t.tree.Len() < 2 || t.cmp(start, end) >= 0 {
+	if t.tree.Len() < 2 {
 		return
 	}
-	var eh enumerateHelper[B, P]
-	// Handle the case where we don't have a boundary equal to start; we have to
-	// find the region that contains it.
-	if rStart, rProp, ok := t.tree.SeekLE(start); ok && t.cmp(rStart, start) < 0 {
-		// This is the first addRegion call, so we won't emit anything.
-		eh.addRegion(start, rProp, t.propEq, nil)
+	// If both bounds have keys, check ordering.
+	if !lower.isMin && !upper.isMax && t.cmp(lower.key, upper.key) >= 0 {
+		return
 	}
+
+	var eh enumerateHelper[B, P]
+
+	// For GE(start): find region containing start via SeekLE.
+	// For Min(): skip this step.
+	if !lower.isMin {
+		if rStart, rProp, ok := t.tree.SeekLE(lower.key); ok && t.cmp(rStart, lower.key) < 0 {
+			// This is the first addRegion call, so we won't emit anything.
+			eh.addRegion(lower.key, rProp, t.propEq, nil)
+		}
+	}
+
 	var toDelete []B
-	for rStart, rProp := range t.tree.Ascend(btreemap.GE(start), btreemap.LT(end)) {
+	for rStart, rProp := range t.tree.Ascend(lower.btreemapBound(), upper.btreemapBound()) {
 		eh.addRegion(rStart, rProp, t.propEq, emit)
 		if withGC && eh.canDeleteLastBoundary {
 			toDelete = append(toDelete, rStart)
@@ -247,34 +299,54 @@ func (t *T[B, P]) enumerate(
 			break
 		}
 	}
-	eh.finish(end, t.propEq, emit)
+
+	// For LT(end): clamp last region via finish.
+	// For Max(): skip (last tree region has zero prop, naturally terminates).
+	if !upper.isMax {
+		eh.finish(upper.key, t.propEq, emit)
+	}
+
 	for _, b := range toDelete {
 		t.tree.Delete(b)
 	}
 }
 
-// Any returns true if [start, end) overlaps any region with property that
+// Any returns true if the given range overlaps any region with property that
 // satisfies the given function.
 //
 // Any can be called concurrently with other read-only methods (as long as
 // WithGC is not used).
-func (t *T[B, P]) Any(start, end B, propFn func(prop P) bool, opts ...Option) bool {
-	return t.any(start, end, propFn, hasWithGC(opts))
+func (t *T[B, P]) Any(
+	lower LowerBound[B], upper UpperBound[B], propFn func(prop P) bool, opts ...Option,
+) bool {
+	return t.any(lower, upper, propFn, hasWithGC(opts))
 }
 
-// Any returns true if [start, end) overlaps any region with property that
-// satisfies the given function.
-func (t *T[B, P]) any(start, end B, propFn func(prop P) bool, withGC bool) bool {
-	if t.cmp(start, end) >= 0 {
+func (t *T[B, P]) any(
+	lower LowerBound[B], upper UpperBound[B], propFn func(prop P) bool, withGC bool,
+) bool {
+	// If both bounds have keys, check ordering.
+	if !lower.isMin && !upper.isMax && t.cmp(lower.key, upper.key) >= 0 {
 		return false
 	}
-	startBoundaryExists, lastProp := t.startBoundaryInfo(start)
-	if !startBoundaryExists && propFn(lastProp) {
+
+	// For GE(start): check the region containing start (it may not have a
+	// boundary). For Min(): the implicit region before the first boundary has
+	// zero property; check propFn against it.
+	var lastProp P
+	if !lower.isMin {
+		startBoundaryExists, beforeProp := t.startBoundaryInfo(lower.key)
+		if !startBoundaryExists && propFn(beforeProp) {
+			return true
+		}
+		lastProp = beforeProp
+	} else if propFn(lastProp) {
 		return true
 	}
+
 	found := false
 	var toDelete []B
-	for rStart, rProp := range t.tree.Ascend(btreemap.GE(start), btreemap.LT(end)) {
+	for rStart, rProp := range t.tree.Ascend(lower.btreemapBound(), upper.btreemapBound()) {
 		if withGC && t.propEq(rProp, lastProp) {
 			toDelete = append(toDelete, rStart)
 		}
@@ -290,7 +362,8 @@ func (t *T[B, P]) any(start, end B, propFn func(prop P) bool, withGC bool) bool 
 	return found
 }
 
-// All emits all regions with non-zero property.
+// All emits all regions with non-zero property. It is a shorthand for
+// Enumerate(Min[B](), Max[B]()).
 //
 // Two consecutive regions can "touch" but not overlap; if they touch, their
 // properties are not equal.
@@ -305,20 +378,7 @@ func (t *T[B, P]) All(opts ...Option) iter.Seq2[axisds.Interval[B], P] {
 }
 
 func (t *T[B, P]) all(emit func(i axisds.Interval[B], prop P) bool, withGC bool) {
-	var eh enumerateHelper[B, P]
-	var toDelete []B
-	for rStart, rProp := range t.tree.Ascend(btreemap.Min[B](), btreemap.Max[B]()) {
-		eh.addRegion(rStart, rProp, t.propEq, emit)
-		if withGC && eh.canDeleteLastBoundary {
-			toDelete = append(toDelete, rStart)
-		}
-		if eh.stopEmitting {
-			break
-		}
-	}
-	for _, b := range toDelete {
-		t.tree.Delete(b)
-	}
+	t.enumerate(Min[B](), Max[B](), emit, withGC)
 }
 
 type enumerateHelper[B Boundary, P Property] struct {

--- a/regiontree/region_tree.go
+++ b/regiontree/region_tree.go
@@ -19,7 +19,7 @@ import (
 	"iter"
 	"strings"
 
-	"github.com/RaduBerinde/axisds/v2"
+	"github.com/RaduBerinde/axisds/v3"
 	"github.com/RaduBerinde/btreemap"
 )
 

--- a/regiontree/region_tree.go
+++ b/regiontree/region_tree.go
@@ -42,6 +42,28 @@ type Property any
 // A zero property value is any value that is equal to the zero P value.
 type PropertyEqualFn[P Property] func(a, b P) bool
 
+// Option configures the behavior of region tree query methods.
+type Option struct {
+	withGC bool
+}
+
+// WithGC is an option that enables garbage collection of unnecessary
+// boundaries between regions with properties that have become equal.
+//
+// This option is only useful to improve performance when the PropertyEqualFn
+// can change over time. Methods called with this option cannot be called
+// concurrently with any other methods.
+var WithGC = Option{withGC: true}
+
+func hasWithGC(opts []Option) bool {
+	for _, o := range opts {
+		if o.withGC {
+			return true
+		}
+	}
+	return false
+}
+
 // T is a tree of regions which fragment a one-dimensional space. Regions have
 // boundaries of type B and each region maintains a property P. Neighboring
 // regions with equal properties are automatically merged.
@@ -193,23 +215,12 @@ func (t *T[B, P]) endBoundaryInfo(end B) (exists bool, afterProp P) {
 // Two consecutive regions can "touch" but not overlap; if they touch, their
 // properties are not equal.
 //
-// Enumerate can be called concurrently with other read-only methods.
-func (t *T[B, P]) Enumerate(start, end B) iter.Seq2[axisds.Interval[B], P] {
+// Enumerate can be called concurrently with other read-only methods (as long as
+// WithGC is not used).
+func (t *T[B, P]) Enumerate(start, end B, opts ...Option) iter.Seq2[axisds.Interval[B], P] {
+	gc := hasWithGC(opts)
 	return func(yield func(i axisds.Interval[B], prop P) bool) {
-		t.enumerate(start, end, yield, false /* no GC */)
-	}
-}
-
-// EnumerateWithGC is a variant of Enumerate which internally deletes
-// unnecessary boundaries between regions with properties that have become
-// equal.
-//
-// This variant is only useful to improve performance when the PropertyEqualFn
-// can change over time. It cannot be called concurrently with any other
-// methods.
-func (t *T[B, P]) EnumerateWithGC(start, end B) iter.Seq2[axisds.Interval[B], P] {
-	return func(yield func(i axisds.Interval[B], prop P) bool) {
-		t.enumerate(start, end, yield, true /* with GC */)
+		t.enumerate(start, end, yield, gc)
 	}
 }
 
@@ -245,19 +256,10 @@ func (t *T[B, P]) enumerate(
 // Any returns true if [start, end) overlaps any region with property that
 // satisfies the given function.
 //
-// Any can be called concurrently with other read-only methods.
-func (t *T[B, P]) Any(start, end B, propFn func(prop P) bool) bool {
-	return t.any(start, end, propFn, false /* withGC */)
-}
-
-// AnyWithGC is a variant of Any which internally deletes unnecessary boundaries
-// between regions with properties that have become equal.
-//
-// This variant is only useful to improve performance when the PropertyEqualFn
-// can change over time. It cannot be called concurrently with any other
-// methods.
-func (t *T[B, P]) AnyWithGC(start, end B, propFn func(prop P) bool) bool {
-	return t.any(start, end, propFn, true /* withGC */)
+// Any can be called concurrently with other read-only methods (as long as
+// WithGC is not used).
+func (t *T[B, P]) Any(start, end B, propFn func(prop P) bool, opts ...Option) bool {
+	return t.any(start, end, propFn, hasWithGC(opts))
 }
 
 // Any returns true if [start, end) overlaps any region with property that
@@ -293,22 +295,12 @@ func (t *T[B, P]) any(start, end B, propFn func(prop P) bool, withGC bool) bool 
 // Two consecutive regions can "touch" but not overlap; if they touch, their
 // properties are not equal.
 //
-// All can be called concurrently with other read-only methods.
-func (t *T[B, P]) All() iter.Seq2[axisds.Interval[B], P] {
+// All can be called concurrently with other read-only methods (as long as
+// WithGC is not used).
+func (t *T[B, P]) All(opts ...Option) iter.Seq2[axisds.Interval[B], P] {
+	gc := hasWithGC(opts)
 	return func(yield func(i axisds.Interval[B], prop P) bool) {
-		t.all(yield, false /* no GC */)
-	}
-}
-
-// AllWithGC is a variant of All which internally deletes unnecessary boundaries
-// between regions with properties that have become equal.
-//
-// This variant is only useful to improve performance when the PropertyEqualFn
-// can change over time. It cannot be called concurrently with any other
-// methods.
-func (t *T[B, P]) AllWithGC() iter.Seq2[axisds.Interval[B], P] {
-	return func(yield func(i axisds.Interval[B], prop P) bool) {
-		t.all(yield, true /* with GC */)
+		t.all(yield, gc)
 	}
 }
 

--- a/regiontree/region_tree.go
+++ b/regiontree/region_tree.go
@@ -311,6 +311,73 @@ func (t *T[B, P]) enumerate(
 	}
 }
 
+// EnumerateDesc enumerates all regions with non-zero property in the given
+// range, in descending order of position. The upper bound is listed first and
+// the lower bound second, matching the direction of iteration.
+//
+// The emitted intervals still have Start < End; only the iteration order is
+// reversed.
+//
+// EnumerateDesc can be called concurrently with other read-only methods (as
+// long as WithGC is not used).
+func (t *T[B, P]) EnumerateDesc(
+	upper UpperBound[B], lower LowerBound[B], opts ...Option,
+) iter.Seq2[axisds.Interval[B], P] {
+	gc := hasWithGC(opts)
+	return func(yield func(i axisds.Interval[B], prop P) bool) {
+		t.enumerateDesc(upper, lower, yield, gc)
+	}
+}
+
+func (t *T[B, P]) enumerateDesc(
+	upper UpperBound[B],
+	lower LowerBound[B],
+	emit func(i axisds.Interval[B], prop P) bool,
+	withGC bool,
+) {
+	if t.tree.Len() < 2 {
+		return
+	}
+	// If both bounds have keys, check ordering.
+	if !lower.isMin && !upper.isMax && t.cmp(lower.key, upper.key) >= 0 {
+		return
+	}
+
+	var dh enumerateDescHelper[B, P]
+
+	// For LT(end): set the initial upper boundary for the first region.
+	if !upper.isMax {
+		dh.regionEnd = upper.key
+		dh.regionEndSet = true
+	}
+
+	var toDelete []B
+	for rStart, rProp := range t.tree.Descend(upper.btreemapBound(), lower.btreemapBound()) {
+		if deleteKey, ok := dh.addBoundary(rStart, rProp, t.propEq, emit); ok && withGC {
+			toDelete = append(toDelete, deleteKey)
+		}
+		if dh.stopEmitting {
+			break
+		}
+	}
+
+	// For GE(start): check if there's a region containing start that extends
+	// below the lowest boundary in the descend range.
+	if !lower.isMin && dh.regionEndSet && !dh.stopEmitting {
+		if _, rProp, ok := t.tree.SeekLT(lower.key); ok && t.cmp(dh.regionEnd, lower.key) > 0 {
+			if deleteKey, ok := dh.addLowerBound(lower.key, rProp, t.propEq, emit); ok && withGC {
+				toDelete = append(toDelete, deleteKey)
+			}
+		}
+	}
+
+	dh.emitPending(t.propEq, emit)
+
+	for _, b := range toDelete {
+		t.tree.Delete(b)
+	}
+}
+
 // Any returns true if the given range overlaps any region with property that
 // satisfies the given function.
 //
@@ -421,6 +488,98 @@ func (eh *enumerateHelper[B, P]) finish(
 		interval := axisds.Interval[B]{Start: eh.lastBoundary, End: end}
 		emitFn(interval, eh.lastProp)
 	}
+}
+
+type enumerateDescHelper[B Boundary, P Property] struct {
+	// regionEnd is the end boundary for the next region to be formed.
+	regionEnd    B
+	regionEndSet bool
+
+	// Pending region [pendingStart, pendingEnd) with pendingProp, waiting to
+	// be emitted. Emission is delayed to allow merging adjacent regions with
+	// equal properties (needed for correct GC output).
+	pendingStart B
+	pendingEnd   B
+	pendingProp  P
+	hasPending   bool
+
+	stopEmitting bool
+}
+
+// addBoundary processes a boundary seen during descending iteration. Each
+// boundary marks the start of a region extending up to regionEnd.
+//
+// Returns (deleteKey, true) if a boundary should be deleted for GC.
+func (dh *enumerateDescHelper[B, P]) addBoundary(
+	boundary B, prop P, propEq PropertyEqualFn[P], emitFn func(i axisds.Interval[B], prop P) bool,
+) (deleteKey B, shouldDelete bool) {
+	if !dh.regionEndSet {
+		// First boundary (Max() upper bound): record as region end.
+		dh.regionEnd = boundary
+		dh.regionEndSet = true
+		return
+	}
+
+	// Region [boundary, regionEnd) has property prop.
+	if dh.hasPending && propEq(prop, dh.pendingProp) {
+		// Merge with pending: extend it downward. The boundary at pendingStart
+		// separates two equal-property regions and can be deleted.
+		deleteKey = dh.pendingStart
+		shouldDelete = true
+		dh.pendingStart = boundary
+	} else {
+		// Emit existing pending region, then start a new one.
+		dh.emitPending(propEq, emitFn)
+		if dh.stopEmitting {
+			return
+		}
+		dh.pendingStart = boundary
+		dh.pendingEnd = dh.regionEnd
+		dh.pendingProp = prop
+		dh.hasPending = true
+	}
+	dh.regionEnd = boundary
+	return
+}
+
+// addLowerBound handles the region extending below the lowest boundary in the
+// descend range, clamped at start.
+//
+// Returns (deleteKey, true) if a boundary should be deleted for GC.
+func (dh *enumerateDescHelper[B, P]) addLowerBound(
+	start B, prop P, propEq PropertyEqualFn[P], emitFn func(i axisds.Interval[B], prop P) bool,
+) (deleteKey B, shouldDelete bool) {
+	if dh.hasPending && propEq(prop, dh.pendingProp) {
+		// Merge with pending.
+		deleteKey = dh.pendingStart
+		shouldDelete = true
+		dh.pendingStart = start
+	} else {
+		dh.emitPending(propEq, emitFn)
+		if dh.stopEmitting {
+			return
+		}
+		dh.pendingStart = start
+		dh.pendingEnd = dh.regionEnd
+		dh.pendingProp = prop
+		dh.hasPending = true
+	}
+	return
+}
+
+func (dh *enumerateDescHelper[B, P]) emitPending(
+	propEq PropertyEqualFn[P], emitFn func(i axisds.Interval[B], prop P) bool,
+) {
+	if !dh.hasPending || dh.stopEmitting {
+		return
+	}
+	if !propEq(zero[P](), dh.pendingProp) {
+		interval := axisds.Interval[B]{Start: dh.pendingStart, End: dh.pendingEnd}
+		if !emitFn(interval, dh.pendingProp) {
+			dh.stopEmitting = true
+		}
+	}
+	dh.hasPending = false
 }
 
 // IsEmpty returns true if the tree contains no regions with non-zero property.

--- a/regiontree/region_tree_bench_test.go
+++ b/regiontree/region_tree_bench_test.go
@@ -72,7 +72,7 @@ func benchRegionTree[B any](
 			// Reset all properties in the range.
 			rt.Update(start, end, func(p int) int { return 0 })
 		default:
-			for _, prop := range rt.Enumerate(start, end) {
+			for _, prop := range rt.Enumerate(GE(start), LT(end)) {
 				x += prop
 			}
 		}

--- a/regiontree/region_tree_test.go
+++ b/regiontree/region_tree_test.go
@@ -154,11 +154,19 @@ func TestRegionTreeRand(t *testing.T) {
 
 			case 2:
 				value := rng.IntN(10) - 5
-				withGC := rand.IntN(2) == 0
-				actual := rt.any(a, b, func(prop int) bool { return prop == value }, withGC)
-				expected := n.Any(a, b, func(prop int) bool { return prop == value })
+				withGC := rng.IntN(2) == 0
+				lower, naiveA := randLowerBound(rng, a)
+				upper, naiveB := randUpperBound(rng, b)
+				propFn := func(prop int) bool { return prop == value }
+				actual := rt.any(lower, upper, propFn, withGC)
+				expected := n.Any(naiveA, naiveB, propFn)
+				// When Min() is used, the tree covers (−∞, 0) which always has
+				// zero property; the naive model can't represent this range.
+				if lower.isMin && propFn(0) {
+					expected = true
+				}
 				if actual != expected {
-					t.Fatalf("Any(%d,%d,%d) mismatch: expected %t, got %t\n%s", a, b, value, expected, actual, debugLog.String())
+					t.Fatalf("Any(%v,%v,%d) mismatch: expected %t, got %t\n%s", lower, upper, value, expected, actual, debugLog.String())
 				}
 
 			case 3:
@@ -168,22 +176,42 @@ func TestRegionTreeRand(t *testing.T) {
 
 			default:
 				var b1, b2 strings.Builder
-				withGC := rand.IntN(2) == 0
-				rt.enumerate(a, b, func(i axisds.Interval[int], val int) bool {
+				withGC := rng.IntN(2) == 0
+				lower, naiveA := randLowerBound(rng, a)
+				upper, naiveB := randUpperBound(rng, b)
+				rt.enumerate(lower, upper, func(i axisds.Interval[int], val int) bool {
 					fmt.Fprintf(&b1, "  [%d, %d) = %d\n", i.Start, i.End, val)
 					return true
 				}, withGC)
-				n.Enumerate(a, b, func(start, end, val int) {
+				n.Enumerate(naiveA, naiveB, func(start, end, val int) {
 					fmt.Fprintf(&b2, "  [%d, %d) = %d\n", start, end, val)
 				})
 				if b1.String() != b2.String() {
-					t.Fatalf("Enumerate(%d,%d) mismatch:\n%sexpected:\n%s\n%s", a, b, b1.String(), b2.String(), debugLog.String())
+					t.Fatalf("Enumerate(%v,%v) mismatch:\n%sexpected:\n%s\n%s", lower, upper, b1.String(), b2.String(), debugLog.String())
 				}
 			}
 
 			rt.CheckInvariants()
 		}
 	}
+}
+
+// randLowerBound randomly returns either GE(key) or Min(). When Min() is
+// returned, the naive equivalent bound (0) is returned as the second value.
+func randLowerBound(rng *rand.Rand, key int) (LowerBound[int], int) {
+	if rng.IntN(4) == 0 {
+		return Min[int](), 0
+	}
+	return GE(key), key
+}
+
+// randUpperBound randomly returns either LT(key) or Max(). When Max() is
+// returned, the naive equivalent bound (maxRange) is returned as the second value.
+func randUpperBound(rng *rand.Rand, key int) (UpperBound[int], int) {
+	if rng.IntN(4) == 0 {
+		return Max[int](), maxRange
+	}
+	return LT(key), key
 }
 
 const maxRange = 1000
@@ -279,7 +307,7 @@ func TestWithGC(t *testing.T) {
 	// Increase global so that values 3, 5, and 2 become effectively zero.
 	global = 5
 	// Without GC, results should reflect effective values but boundaries remain.
-	got := collect(rt.Enumerate(0, 50))
+	got := collect(rt.Enumerate(GE(0), LT(50)))
 	exp := [][3]int{{20, 30, 15}}
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Enumerate without GC: expected %v, got %v", exp, got)
@@ -289,7 +317,7 @@ func TestWithGC(t *testing.T) {
 	}
 
 	// With GC, same results but unnecessary boundaries should be cleaned up.
-	got = collect(rt.Enumerate(0, 50, WithGC))
+	got = collect(rt.Enumerate(GE(0), LT(50), WithGC))
 	if !reflect.DeepEqual(got, exp) {
 		t.Fatalf("Enumerate with GC: expected %v, got %v", exp, got)
 	}
@@ -313,14 +341,14 @@ func TestWithGC(t *testing.T) {
 
 	global = 3
 	// Any without GC.
-	if !rt.Any(0, 30, func(prop int) bool { return max(0, prop-global) > 0 }) {
+	if !rt.Any(GE(0), LT(30), func(prop int) bool { return max(0, prop-global) > 0 }) {
 		t.Fatalf("Any should find region with effective value > 0")
 	}
 	if rt.InternalLen() != initialLen {
 		t.Fatalf("InternalLen should not change without GC")
 	}
 	// Any with GC.
-	if !rt.Any(0, 30, func(prop int) bool { return max(0, prop-global) > 0 }, WithGC) {
+	if !rt.Any(GE(0), LT(30), func(prop int) bool { return max(0, prop-global) > 0 }, WithGC) {
 		t.Fatalf("Any with GC should find region with effective value > 0")
 	}
 	if rt.InternalLen() >= initialLen {
@@ -354,7 +382,7 @@ func TestWithGC(t *testing.T) {
 func TestClone(t *testing.T) {
 	expect := func(rt *T[int, int], vals ...int) {
 		var r [][3]int
-		for i, prop := range rt.Enumerate(0, 1000) {
+		for i, prop := range rt.Enumerate(GE(0), LT(1000)) {
 			r = append(r, [3]int{i.Start, i.End, prop})
 		}
 		var exp [][3]int

--- a/regiontree/region_tree_test.go
+++ b/regiontree/region_tree_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"cmp"
 	"fmt"
+	"iter"
 	"math/rand/v2"
 	"reflect"
 	"strings"
@@ -239,6 +240,115 @@ func (n *naiveInts) IsEmpty() bool {
 		}
 	}
 	return true
+}
+
+func TestWithGC(t *testing.T) {
+	// global is a threshold; properties with value <= global are effectively
+	// zero (they all compare equal to 0).
+	global := 0
+	rt := Make[int, int](cmp.Compare[int], func(a, b int) bool {
+		ea, eb := max(0, a-global), max(0, b-global)
+		return ea == eb
+	})
+
+	// Set up regions with adjacent values that will become equal after
+	// increasing global: [0,10)=3  [10,20)=5  [20,30)=15  [30,40)=2
+	// After global=5: effective values are 0, 0, 10, 0.
+	// Adjacent pairs (3,5)→(0,0) and (2,0)→(0,0) become equal, so boundaries
+	// at 10 and 40 can be GC'd.
+	rt.Update(0, 10, func(int) int { return 3 })
+	rt.Update(10, 20, func(int) int { return 5 })
+	rt.Update(20, 30, func(int) int { return 15 })
+	rt.Update(30, 40, func(int) int { return 2 })
+
+	// Collect results from an iterator.
+	collect := func(it iter.Seq2[axisds.Interval[int], int]) [][3]int {
+		var result [][3]int
+		for i, prop := range it {
+			result = append(result, [3]int{i.Start, i.End, prop})
+		}
+		return result
+	}
+
+	// Initially all four regions are present (4 starts + 1 trailing zero).
+	initialLen := rt.InternalLen()
+	if initialLen != 5 {
+		t.Fatalf("expected InternalLen 5, got %d", initialLen)
+	}
+
+	// Increase global so that values 3, 5, and 2 become effectively zero.
+	global = 5
+	// Without GC, results should reflect effective values but boundaries remain.
+	got := collect(rt.Enumerate(0, 50))
+	exp := [][3]int{{20, 30, 15}}
+	if !reflect.DeepEqual(got, exp) {
+		t.Fatalf("Enumerate without GC: expected %v, got %v", exp, got)
+	}
+	if rt.InternalLen() != initialLen {
+		t.Fatalf("InternalLen should not have changed without GC: expected %d, got %d", initialLen, rt.InternalLen())
+	}
+
+	// With GC, same results but unnecessary boundaries should be cleaned up.
+	got = collect(rt.Enumerate(0, 50, WithGC))
+	if !reflect.DeepEqual(got, exp) {
+		t.Fatalf("Enumerate with GC: expected %v, got %v", exp, got)
+	}
+	gcLen := rt.InternalLen()
+	if gcLen >= initialLen {
+		t.Fatalf("InternalLen should have decreased after GC: was %d, now %d", initialLen, gcLen)
+	}
+
+	// Test Any with GC.
+	global = 0
+	rt = Make[int, int](cmp.Compare[int], func(a, b int) bool {
+		ea, eb := max(0, a-global), max(0, b-global)
+		return ea == eb
+	})
+	// [0,10)=2  [10,20)=1  [20,30)=7
+	// After global=3: effective 0, 0, 4. Boundary at 10 becomes GC-able.
+	rt.Update(0, 10, func(int) int { return 2 })
+	rt.Update(10, 20, func(int) int { return 1 })
+	rt.Update(20, 30, func(int) int { return 7 })
+	initialLen = rt.InternalLen()
+
+	global = 3
+	// Any without GC.
+	if !rt.Any(0, 30, func(prop int) bool { return max(0, prop-global) > 0 }) {
+		t.Fatalf("Any should find region with effective value > 0")
+	}
+	if rt.InternalLen() != initialLen {
+		t.Fatalf("InternalLen should not change without GC")
+	}
+	// Any with GC.
+	if !rt.Any(0, 30, func(prop int) bool { return max(0, prop-global) > 0 }, WithGC) {
+		t.Fatalf("Any with GC should find region with effective value > 0")
+	}
+	if rt.InternalLen() >= initialLen {
+		t.Fatalf("InternalLen should decrease after Any with GC: was %d, now %d", initialLen, rt.InternalLen())
+	}
+
+	// Test All with GC.
+	global = 0
+	rt = Make[int, int](cmp.Compare[int], func(a, b int) bool {
+		ea, eb := max(0, a-global), max(0, b-global)
+		return ea == eb
+	})
+	// [0,10)=4  [10,20)=3  [20,30)=9
+	// After global=4: effective 0, 0, 5. Boundary at 10 becomes GC-able.
+	rt.Update(0, 10, func(int) int { return 4 })
+	rt.Update(10, 20, func(int) int { return 3 })
+	rt.Update(20, 30, func(int) int { return 9 })
+	initialLen = rt.InternalLen()
+
+	global = 4
+	got = collect(rt.All(WithGC))
+	exp = [][3]int{{20, 30, 9}}
+	if !reflect.DeepEqual(got, exp) {
+		t.Fatalf("All with GC: expected %v, got %v", exp, got)
+	}
+	if rt.InternalLen() >= initialLen {
+		t.Fatalf("InternalLen should decrease after All with GC: was %d, now %d", initialLen, rt.InternalLen())
+	}
 }
 
 func TestClone(t *testing.T) {

--- a/regiontree/region_tree_test.go
+++ b/regiontree/region_tree_test.go
@@ -174,6 +174,28 @@ func TestRegionTreeRand(t *testing.T) {
 					t.Fatalf("IsEmpty %t instead of %t\n%s", actual, exp, debugLog.String())
 				}
 
+			case 4:
+				// Test EnumerateDesc against naive (reversed).
+				var b1 strings.Builder
+				withGC := rng.IntN(2) == 0
+				lower, naiveA := randLowerBound(rng, a)
+				upper, naiveB := randUpperBound(rng, b)
+				rt.enumerateDesc(upper, lower, func(i axisds.Interval[int], val int) bool {
+					fmt.Fprintf(&b1, "  [%d, %d) = %d\n", i.Start, i.End, val)
+					return true
+				}, withGC)
+				var naiveResults []string
+				n.Enumerate(naiveA, naiveB, func(start, end, val int) {
+					naiveResults = append(naiveResults, fmt.Sprintf("  [%d, %d) = %d\n", start, end, val))
+				})
+				var b2 strings.Builder
+				for i := len(naiveResults) - 1; i >= 0; i-- {
+					b2.WriteString(naiveResults[i])
+				}
+				if b1.String() != b2.String() {
+					t.Fatalf("EnumerateDesc(%v,%v) mismatch:\n%sexpected:\n%s\n%s", upper, lower, b1.String(), b2.String(), debugLog.String())
+				}
+
 			default:
 				var b1, b2 strings.Builder
 				withGC := rng.IntN(2) == 0
@@ -376,6 +398,40 @@ func TestWithGC(t *testing.T) {
 	}
 	if rt.InternalLen() >= initialLen {
 		t.Fatalf("InternalLen should decrease after All with GC: was %d, now %d", initialLen, rt.InternalLen())
+	}
+
+	// Test EnumerateDesc with GC.
+	global = 0
+	rt = Make[int, int](cmp.Compare[int], func(a, b int) bool {
+		ea, eb := max(0, a-global), max(0, b-global)
+		return ea == eb
+	})
+	// [0,10)=3  [10,20)=5  [20,30)=15  [30,40)=2
+	// After global=5: effective 0, 0, 10, 0.
+	// Boundaries at 10 and 40 can be GC'd.
+	rt.Update(0, 10, func(int) int { return 3 })
+	rt.Update(10, 20, func(int) int { return 5 })
+	rt.Update(20, 30, func(int) int { return 15 })
+	rt.Update(30, 40, func(int) int { return 2 })
+	initialLen = rt.InternalLen()
+
+	global = 5
+	// Without GC.
+	got = collect(rt.EnumerateDesc(LT(50), GE(0)))
+	exp = [][3]int{{20, 30, 15}}
+	if !reflect.DeepEqual(got, exp) {
+		t.Fatalf("EnumerateDesc without GC: expected %v, got %v", exp, got)
+	}
+	if rt.InternalLen() != initialLen {
+		t.Fatalf("InternalLen should not have changed without GC: expected %d, got %d", initialLen, rt.InternalLen())
+	}
+	// With GC.
+	got = collect(rt.EnumerateDesc(LT(50), GE(0), WithGC))
+	if !reflect.DeepEqual(got, exp) {
+		t.Fatalf("EnumerateDesc with GC: expected %v, got %v", exp, got)
+	}
+	if rt.InternalLen() >= initialLen {
+		t.Fatalf("InternalLen should have decreased after EnumerateDesc with GC: was %d, now %d", initialLen, rt.InternalLen())
 	}
 }
 

--- a/regiontree/region_tree_test.go
+++ b/regiontree/region_tree_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/RaduBerinde/axisds/v2"
+	"github.com/RaduBerinde/axisds/v3"
 	"github.com/RaduBerinde/btreemap"
 	"github.com/cockroachdb/datadriven"
 )


### PR DESCRIPTION
#### switch to v3

#### regiontree: switch to Option-based API

Consolidate Enumerate/EnumerateWithGC, Any/AnyWithGC, and All/AllWithGC
into single methods that accept variadic Option arguments. The WithGC
option replaces the dedicated WithGC method variants.

#### regiontree: add LowerBound/UpperBound types to query APIs

Replace raw `start, end B` parameters in Enumerate and Any with
LowerBound[B] and UpperBound[B] types, allowing unbounded iteration
via Min()/Max() in addition to the existing GE()/LT() semantics.

The All() method is kept as a convenience shorthand and now delegates
to enumerate(Min(), Max()). Update is unchanged since it needs
concrete boundary values.

The random test is extended to exercise Min()/Max() bounds in
Enumerate queries.

#### regiontree: add EnumerateDesc for reverse-order iteration

Add EnumerateDesc which iterates regions from high to low, complementing
the existing forward Enumerate. Supports WithGC and all bound types.